### PR TITLE
Add ability to automatically form a URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,19 @@ If you use [LambdaCD](https://github.com/flosell/lambdacd) in an environment wit
    * The :ttl key is optional (default: 7) and definies how many days the builds should be stored
    * The :mark-running-steps-as is optional (default: :killed). If you set it to :failure all running steps will be marked with the status :failure. If you set to :success, running steps will me marked as :success. Please be advised that configurating something other than :success, :failure or :killed will leave your pipeline in an undefined state.
    * The :persist-the-output-of-running-steps is optional (default: false). If you set it to true the state of the pipeline will be persisted if the output of any step is changed (-> many write operations). If you set it to false the state of the pipeline will only be persisted if the status of any step is changed (-> fewer write operations).
+   * The :hosts key specifies the hosts of the MongoDB. The key is mandatory to form a URI.
+   * The :user, :password and :port keys are optional. If you set them, they will be used to augment the URI.
+   * The :uri key specifies the URI of the MongoDB. This key is considered deprecated and will only be used as a fallback if the :hosts key is not specified
 2. Add the mongodb configuration map to the main configuration by using the key name :mongodb-cfg
 
 ```clojure
 (defn -main [& args]
   (let [home-dir (util/create-temp-dir)
-        mongodb-cfg {:uri          "mongodb://localhost:27017/lambdacd"
+        mongodb-cfg {:user         "user"
+                     :uri          "mongodb://localhost:27017/lambdacd"
+                     :password     "password"
+                     :hosts        ["localhost"]
+                     :port         27017
                      :db           "lambdacd"
                      :col          "test-project"
                      :max-builds   10
@@ -47,6 +54,8 @@ If you use [LambdaCD](https://github.com/flosell/lambdacd) in an environment wit
         pipeline (lambdacd.core/assemble-pipeline pipeline-def config (mongodb-state/new-mongodb-state config))
         [...]
 ```
+
+   * In this example the URI formed is `mongodb://user:password@localhost:27017/lambdacd`
 
 ## TODO
 

--- a/project.clj
+++ b/project.clj
@@ -5,15 +5,15 @@
                       :url "http://opensource.org/licenses/MIT"}
             :scm {:name "git"
                   :url "https://github.com/SimonMonecke/lambdacd-mongodb.git"}
-            :dependencies [[lambdacd "0.8.0"]
-                           [ring-server "0.3.1"]
-                           [org.clojure/clojure "1.7.0"]
-                           [org.clojure/tools.logging "0.3.0"]
-                           [org.slf4j/slf4j-api "1.7.5"]
-                           [ch.qos.logback/logback-core "1.0.13"]
-                           [ch.qos.logback/logback-classic "1.0.13"]
+            :dependencies [[lambdacd "0.9.0"]
+                           [ring-server "0.4.0"]
+                           [org.clojure/clojure "1.8.0"]
+                           [org.clojure/tools.logging "0.3.1"]
+                           [org.slf4j/slf4j-api "1.7.21"]
+                           [ch.qos.logback/logback-core "1.1.7"]
+                           [ch.qos.logback/logback-classic "1.1.7"]
                            [com.novemberain/monger "3.0.2"]
-                           [com.rpl/specter "0.7.1"]]
+                           [com.rpl/specter "0.10.0"]]
             :test-paths ["test", "example"]
             :profiles {:uberjar {:aot :all}}
             :main example-pipeline.pipeline)

--- a/test/lambda_mongodb/test/mongodb_persistence_write.clj
+++ b/test/lambda_mongodb/test/mongodb_persistence_write.clj
@@ -1,7 +1,6 @@
 (ns lambda-mongodb.test.mongodb-persistence-write
   (:require [clojure.test :refer :all]
-            [lambdacd-mongodb.mongodb-persistence-write :as p]
-            [clj-time.core :as t]))
+            [lambdacd-mongodb.mongodb-persistence-write :as p]))
 
 (deftest test-build-has-only-a-trigger
   (testing "build with only a trigger"

--- a/test/lambda_mongodb/test/mongodb_state.clj
+++ b/test/lambda_mongodb/test/mongodb_state.clj
@@ -1,0 +1,38 @@
+(ns lambda-mongodb.test.mongodb-state
+  (:require [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
+            [lambdacd-mongodb.mongodb-state :as s]))
+
+(def config-without-uri
+  {:db           "db"
+   :col          "col"
+   :pipeline-def "pipeline-def"})
+
+(def config-with-uri
+  (assoc config-without-uri :uri "mongodb://user:password@localhost:27017,locohorst:27017/db"))
+
+(def config-with-uri-parts
+  (assoc config-without-uri :user "user"
+                            :hosts ["localhost" "locohorst"]
+                            :port 27017
+                            :password "password"))
+
+(deftest test-get-mongodb-cfg
+  (with-redefs [log/log* (fn [_ _ _ message] message)]
+    (testing "that it gets a config"
+      (is (= config-with-uri (s/get-mongodb-cfg {:mongodb-cfg config-with-uri}))))
+    (testing "that it forms a uri if not given"
+      (is (= (merge config-with-uri config-with-uri-parts)
+             (s/get-mongodb-cfg {:mongodb-cfg config-with-uri-parts}))))
+    (testing "that it does not need a port"
+      (is (= "mongodb://user:password@localhost,locohorst/db" (:uri (s/get-mongodb-cfg {:mongodb-cfg (dissoc config-with-uri-parts :port)})))))
+    (testing "that it does not need a user"
+      (is (= "mongodb://localhost:27017,locohorst:27017/db" (:uri (s/get-mongodb-cfg {:mongodb-cfg (dissoc config-with-uri-parts :user)})))))
+    (testing "that it does not need a password"
+      (is (= "mongodb://localhost:27017,locohorst:27017/db" (:uri (s/get-mongodb-cfg {:mongodb-cfg (dissoc config-with-uri-parts :password)})))))
+    (testing "that it does need a host"
+      (is (= "LambdaCD-MongoDB: Can't find key(s): #{:uri}" (s/get-mongodb-cfg {:mongodb-cfg (dissoc config-with-uri-parts :hosts)})))
+      (is (= "LambdaCD-MongoDB: Can't find key(s): #{:uri}" (s/get-mongodb-cfg {:mongodb-cfg (assoc config-with-uri-parts :hosts [])}))))
+    (testing "that it only needs one host"
+      (is (= "mongodb://user:password@localhost:27017/db"
+             (:uri (s/get-mongodb-cfg {:mongodb-cfg (assoc config-with-uri-parts :hosts ["localhost"])})))))))


### PR DESCRIPTION
The URI can consist of user, password, hosts, port and database. To make the config more verbose all parts can be specified separately. Only hosts is mandatory.