### PR TITLE
Add readable build numbers feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ If you use [LambdaCD](https://github.com/flosell/lambdacd) in an environment wit
                      :ttl          7
                      :mark-running-steps-as :killed
                      :pipeline-def pipeline-def
-                     :persist-the-output-of-running-steps false}
+                     :persist-the-output-of-running-steps false
+                     :use-readable-build-numbers true}
         config {:mongodb-cfg              mongodb-cfg
                 :home-dir                 home-dir
                 :dont-wait-for-completion false}

--- a/src/lambdacd_mongodb/mongodb_persistence_write.clj
+++ b/src/lambdacd_mongodb/mongodb_persistence_write.clj
@@ -13,7 +13,7 @@
 (defn- formatted-step-id [step-id]
   (str/join "-" step-id))
 
-(defn build-has-only-a-trigger [build]
+(defn only-trigger? [build]
   (every? #(= % 1)
           (select [ALL FIRST LAST] build)))
 
@@ -77,9 +77,9 @@
         (log/error "LambdaCD-MongoDB: Write to DB: An unexpected error occurred")
         (log/error "LambdaCD-MongoDB: caught" (.getMessage e))))))
 
-(defn write-build-history [mongodb-uri mongodb-db mongodb-col persist-the-output-of-running-steps build-number old-state new-state ttl pipeline-def]
-  (when (not (build-has-only-a-trigger (get new-state build-number)))
-    (if persist-the-output-of-running-steps
+(defn write-build-history [mongodb-uri mongodb-db mongodb-col persist-output-of-running-steps? build-number old-state new-state ttl pipeline-def]
+  (when (not (only-trigger? (get new-state build-number)))
+    (if persist-output-of-running-steps?
       (write-to-mongo-db mongodb-uri mongodb-db mongodb-col build-number new-state ttl pipeline-def)
       (let [old-state-only-with-status (state-only-with-status (get old-state build-number))
             new-state-only-with-status (state-only-with-status (get new-state build-number))]

--- a/test/lambda_mongodb/test/mongodb_persistence_write.clj
+++ b/test/lambda_mongodb/test/mongodb_persistence_write.clj
@@ -4,11 +4,11 @@
 
 (deftest test-build-has-only-a-trigger
   (testing "build with only a trigger"
-    (is (p/build-has-only-a-trigger {'(1) {:status :success}})))
+    (is (p/only-trigger? {'(1) {:status :success}})))
   (testing "build with only a trigger with nested steps"
-    (is (p/build-has-only-a-trigger {'(1) {:status :success} '(2 1) {:status :success} '(3 1) {:status :success :foo :bar}})))
+    (is (p/only-trigger? {'(1) {:status :success} '(2 1) {:status :success} '(3 1) {:status :success :foo :bar}})))
   (testing "build with two steps"
-    (is (not (p/build-has-only-a-trigger {'(1) {:status :success} '(2 1) {:status :success} '(2) {:status :success :foo :bar}})))))
+    (is (not (p/only-trigger? {'(1) {:status :success} '(2 1) {:status :success} '(2) {:status :success :foo :bar}})))))
 
 (deftest test-step-id-lists->string
   (testing "should convert list keywords"


### PR DESCRIPTION
When the `:use-readable-build-numbers` option in the mongodb cfg part is set to `true`, a counter (starting from 1) is now used for build numbers. The counter is persisted in the mongo collection.
This should help readability of Builds in the UI.